### PR TITLE
v12 fatjet id fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,7 @@ Thumbs.db
 
 *.root
 *.parquet
+*.txt
 test.ipynb
 **/__pycache__
 **/.DS_Store
@@ -183,8 +184,6 @@ src/HH4b/boosted/**/*.pkl
 **/*.json
 
 !data/*.json
-
-running_jobs.txt
 
 .bashrc
 .condor_config

--- a/src/bbtautau/processors/bbtautauSkimmer.py
+++ b/src/bbtautau/processors/bbtautauSkimmer.py
@@ -294,7 +294,7 @@ class bbtautauSkimmer(SkimmerABC):
 
         print("ak4 JECs", f"{time.time() - start:.2f}")
 
-        jets = objects.good_ak4jets(jets)
+        jets = objects.good_ak4jets(jets, nano_version=self._nano_version)
         ht = ak.sum(jets.pt, axis=1)
         print("ak4", f"{time.time() - start:.2f}")
 
@@ -314,7 +314,9 @@ class bbtautauSkimmer(SkimmerABC):
         )
         print("ak8 JECs", f"{time.time() - start:.2f}")
 
-        fatjets = objects.good_ak8jets(fatjets, **self.fatjet_selection)
+        fatjets = objects.good_ak8jets(
+            fatjets, **self.fatjet_selection, nano_version=self._nano_version
+        )
 
         # # TODO: VBF objects
         # vbf_jets = objects.vbf_jets(

--- a/src/bbtautau/processors/bbtautauSkimmer.py
+++ b/src/bbtautau/processors/bbtautauSkimmer.py
@@ -143,7 +143,7 @@ class bbtautauSkimmer(SkimmerABC):
         xsecs: dict = None,
         save_systematics: bool = False,
         region: str = "signal",
-        nano_version: str = "v12",
+        nano_version: str = "v12_private",
     ):
         super().__init__()
 

--- a/src/bbtautau/processors/objects.py
+++ b/src/bbtautau/processors/objects.py
@@ -87,10 +87,14 @@ def good_ak8jets(
     eta: float,
     msd: float,  # noqa: ARG001
     mreg: float,  # noqa: ARG001
-    mreg_str="particleNet_mass_legacy",  # noqa: ARG001
+    nano_version: str,
+    mreg_str: str = "particleNet_mass_legacy",  # noqa: ARG001
 ):
+    if nano_version.startswith("v12"):
+        jetidtight, jetidtightlepveto = jetid_v12(fatjets)  # v12 jetid fix
+    else:
+        raise NotImplementedError(f"Jet ID fix not implemented yet for {nano_version}")
 
-    jetidtight, jetidtightlepveto = jetid_v12(fatjets)  # v12 jetid fix
     fatjet_sel = (
         jetidtight
         & (fatjets.pt > object_pt)
@@ -100,8 +104,11 @@ def good_ak8jets(
     return fatjets[fatjet_sel]
 
 
-def good_ak4jets(jets: JetArray):
-    jetidtight, jetidtightlepveto = jetid_v12(jets)  # v12 jetid fix
+def good_ak4jets(jets: JetArray, nano_version: str):
+    if nano_version.startswith("v12"):
+        jetidtight, jetidtightlepveto = jetid_v12(jets)  # v12 jetid fix
+    else:
+        raise NotImplementedError(f"Jet ID fix not implemented yet for {nano_version}")
     jet_sel = (jets.pt > 15) & (np.abs(jets.eta) < 4.7) & jetidtight & jetidtightlepveto
 
     return jets[jet_sel]

--- a/src/bbtautau/processors/objects.py
+++ b/src/bbtautau/processors/objects.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import awkward as ak
 import numpy as np
+from boostedhh.processors.objects import jetid_v12
 from boostedhh.processors.utils import PDGID
 from coffea.nanoevents.methods.nanoaod import (
     ElectronArray,
@@ -88,8 +89,10 @@ def good_ak8jets(
     mreg: float,  # noqa: ARG001
     mreg_str="particleNet_mass_legacy",  # noqa: ARG001
 ):
+
+    jetidtight, jetidtightlepveto = jetid_v12(fatjets)  # v12 jetid fix
     fatjet_sel = (
-        fatjets.isTight
+        jetidtight
         & (fatjets.pt > object_pt)
         & (abs(fatjets.eta) < eta)
         # & ((fatjets.msoftdrop > msd) | (fatjets[mreg_str] > mreg))
@@ -98,23 +101,7 @@ def good_ak8jets(
 
 
 def good_ak4jets(jets: JetArray):
-    # JetID definitions for nanov12 copying
-    # https://gitlab.cern.ch/cms-jetmet/coordination/coordination/-/issues/117#note_8880716
-    jetidtightbit = (jets.jetId & 2) == 2
-    jetidtight = (
-        ((np.abs(jets.eta) <= 2.7) & jetidtightbit)
-        | (
-            ((np.abs(jets.eta) > 2.7) & (np.abs(jets.eta) <= 3.0))
-            & jetidtightbit
-            & (jets.neHEF >= 0.99)
-        )
-        | ((np.abs(jets.eta) > 3.0) & jetidtightbit & (jets.neEmEF < 0.4))
-    )
-
-    jetidtightlepveto = (
-        (np.abs(jets.eta) <= 2.7) & jetidtight & (jets.muEF < 0.8) & (jets.chEmEF < 0.8)
-    ) | ((np.abs(jets.eta) > 2.7) & jetidtight)
-
+    jetidtight, jetidtightlepveto = jetid_v12(jets)  # v12 jetid fix
     jet_sel = (jets.pt > 15) & (np.abs(jets.eta) < 4.7) & jetidtight & jetidtightlepveto
 
     return jets[jet_sel]


### PR DESCRIPTION
Fixing tight jet ID for AK8 jets as well, based on https://gitlab.cern.ch/cms-jetmet/coordination/coordination/-/issues/117#note_8880716. Doesn't impact us since TightID is the same for $|\eta| < 2.7$. 