### PR TITLE
Dev gen info in sr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,6 @@ src/bbtautau/kubernetes/bdt_trainings/*
 src/bbtautau/postprocessing/templates/
 src/bbtautau/combine/bbtautau_ggfvbf.code-workspace
 src/bbtautau/combine/binder/
+
+# Personal scratch / untracked utilities (kept out of git)
+untracked_utils/

--- a/src/bbtautau/postprocessing/CreateDatacard.py
+++ b/src/bbtautau/postprocessing/CreateDatacard.py
@@ -149,7 +149,7 @@ parser.add_argument(
     "--year",
     type=str,
     default="2022-2023",
-    choices=hh_years + ["2022-2023"],
+    choices=hh_years + ["2022-2023"] + ["all"],
     help="years to make datacards for",
 )
 add_bool_arg(parser, "dd-dyjets", "use data-driven DY jets estimate", default=True)
@@ -266,7 +266,13 @@ for key in all_sig_keys:
 all_mc = list(mc_samples.keys())
 
 
-years = hh_years if args.year == "2022-2023" else [args.year]
+if args.year == "all":
+    years = hh_years
+elif args.year == "2022-2023":
+    years = [year for year in hh_years if year != "2024"]
+else:
+    years = [args.year]
+
 full_lumi = LUMI[args.year]
 
 # jmsr_keys = sig_keys + ["vhtobb", "zz", "nozzdiboson"]

--- a/src/bbtautau/postprocessing/CreateDatacard.py
+++ b/src/bbtautau/postprocessing/CreateDatacard.py
@@ -43,6 +43,7 @@ from bbtautau.postprocessing.datacardHelpers import (
 from bbtautau.postprocessing.Samples import (
     CHANNELS,
     SIGNALS,
+    SM_SIGNALS,
     sig_keys_ggf,
     sig_keys_vbf,
     single_h_keys,
@@ -96,7 +97,7 @@ add_bool_arg(parser, "only-sm", "Only add SM HH samples", default=False)
 
 parser.add_argument(
     "--sigs",
-    default=SIGNALS,
+    default=SM_SIGNALS,
     nargs="*",
     type=str,
     help="specify signals",

--- a/src/bbtautau/postprocessing/Regions.py
+++ b/src/bbtautau/postprocessing/Regions.py
@@ -153,9 +153,15 @@ def get_selection_regions(
     overlapping_channels: bool = False,
     sensitivity_disc_tag: str | None = None,
     ggf_modelname: str | None = None,
+    control_region: bool = False,
 ):
     """
     Get the selection regions for a given signal and channel.
+
+    If ``control_region`` is True, return the CR (orthogonal annulus) regions instead
+    of the nominal SR pass/fail. The SR cuts resolved below are reused as the SR-pass
+    veto, and loose cuts come from ``userConfig.CR_LOOSE_CUTS``.
+    See notes/control_region_plan.md.
     """
 
     # parse bb discriminator
@@ -183,6 +189,22 @@ def get_selection_regions(
     else:
         txbb_cut = channel.txbb_cut
         txtt_cut = channel.txtt_cut if use_ParT else channel.txtt_BDT_cut
+
+    # Control region: orthogonal annulus built from the SR cuts (as veto) + loose cuts.
+    if control_region:
+        from bbtautau.userConfig import CR_LOOSE_CUTS
+
+        loose = CR_LOOSE_CUTS[channel.key]
+        return build_control_regions(
+            channel,
+            signal,
+            use_ParT=use_ParT,
+            bb_disc=bb_disc,
+            txbb_sr=txbb_cut,
+            txtt_sr=txtt_cut,
+            txbb_loose=loose["txbb"],
+            txtt_loose=loose["txtt"],
+        )
 
     pass_cuts = {
         "bbFatJetPt": [250, CUT_MAX_VAL],
@@ -235,3 +257,63 @@ def get_selection_regions(
     }
 
     return regions
+
+
+def _tt_disc_key(channel: Channel, signal: str, use_ParT: bool) -> str:
+    """tt discriminant column name for a channel (ParT or per-channel BDT). Mirrors the
+    disc-key choice inside ``get_selection_regions`` so SR and CR stay consistent."""
+    if use_ParT:
+        return f"ttFatJetParTX{channel.tagger_label}vsQCDTop"
+    return _get_bdt_key(signal, channel, prefix_only=False)
+
+
+def build_control_regions(
+    channel: Channel,
+    signal: str,
+    *,
+    use_ParT: bool,
+    bb_disc: str,
+    txbb_sr: float,
+    txtt_sr: float,
+    txbb_loose: float,
+    txtt_loose: float,
+) -> dict[str, Region]:
+    """Build the CR (orthogonal annulus) regions from explicit cut values.
+
+    Geometry (see notes/control_region_plan.md):
+      CR-pass = (bb > txbb_loose AND tt > txtt_loose) AND (bb < txbb_sr OR tt < txtt_sr)
+                i.e. loose-pass with the SR-pass vetoed out -> orthogonal to the SR.
+      CR-fail = bb < txbb_loose OR tt < txtt_loose  (anti-tag below the loose cuts)
+
+    ``bb_disc`` must already be the event-branch name (``bbFatJet...``, not ``ak8...``).
+    Both regions carry ``signal=False`` so the CR is NOT blinded (we want to see data
+    across the full mass range). Taking explicit loose values keeps this reusable by the
+    yield-scan tooling.
+    """
+    tt_disc = _tt_disc_key(channel, signal, use_ParT)
+
+    base = {
+        "bbFatJetPt": [250, CUT_MAX_VAL],
+        "ttFatJetPt": [200, CUT_MAX_VAL],
+    }
+    # tt-mass window is only applied on the ParT path in the SR; mirror that here.
+    if use_ParT:
+        base[channel.tt_mass_cut[0]] = channel.tt_mass_cut[1]
+
+    pass_cuts = {
+        **base,
+        bb_disc: [txbb_loose, CUT_MAX_VAL],
+        tt_disc: [txtt_loose, CUT_MAX_VAL],
+        # SR-pass veto (OR): bb < txbb_sr OR tt < txtt_sr
+        f"{bb_disc}+{tt_disc}": [[-CUT_MAX_VAL, txbb_sr], [-CUT_MAX_VAL, txtt_sr]],
+    }
+    fail_cuts = {
+        **base,
+        # anti-tag below loose (OR): bb < txbb_loose OR tt < txtt_loose
+        f"{bb_disc}+{tt_disc}": [[-CUT_MAX_VAL, txbb_loose], [-CUT_MAX_VAL, txtt_loose]],
+    }
+
+    return {
+        "pass": Region(cuts=pass_cuts, signal=False, label="Pass CR"),
+        "fail": Region(cuts=fail_cuts, signal=False, label="Fail CR"),
+    }

--- a/src/bbtautau/postprocessing/SensitivityStudy.py
+++ b/src/bbtautau/postprocessing/SensitivityStudy.py
@@ -134,6 +134,7 @@ class Analyser:
         dataMinusSimABCD=False,
         showNonDataDrivenPortion=True,
         compute_ROC_metrics=False,
+        tt_glopart_cut: float | None = None,
     ):
         """Initialize Analyser with support for multiple signals."""
         self.sr_config = sr_config
@@ -143,6 +144,11 @@ class Analyser:
         self.tt_pres = tt_pres
         self.at_inference = at_inference
         self.use_ParT = use_ParT
+
+        # Extra fixed cut on the tt GloParT tagger, applied on top of the tt
+        # discriminant being optimized (BDT or ParT) and the bb discriminant.
+        self.tt_glopart_cut = tt_glopart_cut
+        self.extra_tt_disc_name = f"ttFatJetParTX{CHANNELS[sr_config.channel].tagger_label}vsQCDTop"
 
         self.llsl_weight = llsl_weight
         self.dataMinusSimABCD = dataMinusSimABCD
@@ -466,6 +472,11 @@ class Analyser:
             ),
         }
 
+        if self.tt_glopart_cut is not None:
+            base_vars["txtts_extra"] = self._extract_var_with_cuts(
+                self.extra_tt_disc_name, base_presel_cuts, concatenate_samples=sig_vs_bkg_groups
+            )
+
         # Extract veto discriminant vars
         base_veto_disc_vars = {}
         if self.sr_config.veto_regions:
@@ -509,9 +520,12 @@ class Analyser:
         self.sideband_cuts = copy.deepcopy(self._base_sideband_cuts)
 
     def _pass_cuts(self, group_name, txbbcut, txttcut):
-        return (self.sensitivity_vars["txbbs"][group_name] > txbbcut) & (
+        cuts = (self.sensitivity_vars["txbbs"][group_name] > txbbcut) & (
             self.sensitivity_vars["txtts"][group_name] > txttcut
         )
+        if self.tt_glopart_cut is not None:
+            cuts &= self.sensitivity_vars["txtts_extra"][group_name] > self.tt_glopart_cut
+        return cuts
 
     def compute_sig_bkg_abcd(self, txbbcut, txttcut):
         """Compute signal and background in ABCD regions, after significant cleanup."""
@@ -725,6 +739,7 @@ class Analyser:
         results["channel"] = self.channel.key
         results["years"] = "_".join(self.years)
         results["eval_bmin"] = bmin
+        results["tt_glopart_cut"] = self.tt_glopart_cut
 
         # Print summary
         self._print_evaluation_summary(results, txbbcut, txttcut)
@@ -741,6 +756,8 @@ class Analyser:
         print(f"Evaluation Results for {self.region_name} / {self.channel.key}")
         print(f"{'='*60}")
         print(f"Cuts: txbb > {txbbcut:.4f}, txtt > {txttcut:.4f}")
+        if self.tt_glopart_cut is not None:
+            print(f"Extra cut: {self.extra_tt_disc_name} > {self.tt_glopart_cut:.4f}")
         print(f"Signal yield: {results['sig_pass']:.2f}")
         print(f"Signal efficiency: {results['sig_eff']:.4f}")
         print(f"Background (ABCD): {results['bkg_ABCD']:.2f}")
@@ -1078,7 +1095,7 @@ class Analyser:
             b_min_vals: List of B_min values to optimize
         """
         if b_min_vals is None:
-            b_min_vals = [1, 10] if self.test_mode else DEFAULT_BMIN_VALUES
+            b_min_vals = [1, 10, 12] if self.test_mode else DEFAULT_BMIN_VALUES
 
         if self.test_mode:
             gridlims = (0.3, 1) if use_thresholds else (0.2, 0.9)
@@ -1355,6 +1372,7 @@ def analyse_channel(
     outfile=None,
     dataMinusSimABCD=False,
     showNonDataDrivenPortion=True,
+    tt_glopart_cut=None,
 ):
     """
     Analyse a given signal region configuration for a given channel.
@@ -1365,11 +1383,16 @@ def analyse_channel(
         outfile: Path to output CSV file (for "evaluate" action)
         dataMinusSimABCD: Use enhanced ABCD method (subtract simulated non-QCD)
         showNonDataDrivenPortion: Include non-QCD background in results
+        tt_glopart_cut: Extra fixed cut on the tt GloParT tagger, applied on top of
+            the tt discriminant being optimized (BDT or ParT) and the bb discriminant.
+            Only respected by the "sensitivity" and "evaluate" actions.
     """
 
     print(
         f"Processing configuration: {sr_config.name} for channel: {sr_config.channel}. Test mode: {test_mode}."
     )
+    if tt_glopart_cut is not None:
+        print(f"Extra tt GloParT cut: {tt_glopart_cut}")
 
     # Create analyser with all signals (data and BDT predictions loaded once)
     analyser = Analyser(
@@ -1379,6 +1402,7 @@ def analyse_channel(
         tt_pres=tt_pres,
         use_ParT=use_ParT,
         at_inference=at_inference,
+        tt_glopart_cut=tt_glopart_cut,
         llsl_weight=llsl_weight,
         plot_dir=plot_dir,
         dataMinusSimABCD=dataMinusSimABCD,
@@ -1420,6 +1444,7 @@ def get_plot_dir(
     overlapping_channels: bool,
     sr_config: SRConfig,
     ggf_modelname: str | None = None,
+    tt_glopart_cut: float | None = None,
 ):
 
     if test_mode:
@@ -1430,6 +1455,8 @@ def get_plot_dir(
         test_dir = "full_presel"
 
     disc_tag = "ParT" if use_ParT else ggf_modelname if ggf_modelname else "BDT"
+    if tt_glopart_cut is not None:
+        disc_tag += f"_ttglopart{tt_glopart_cut:.2f}"
 
     tag = f"{disc_tag}/"
     tag += "do_vbf/" if do_vbf else "ggf_only/"
@@ -1485,6 +1512,7 @@ def main(args):
             additional_samples=additional_samples,
             at_inference=args.at_inference,
             unbiased_mc_eval=args.unbiased_mc_eval,
+            restrict_signal_to_channel_gen=args.gen_split,
         )
 
         channel_regions: list[SRConfig] = []  # within current channel (overlapping mode)
@@ -1516,6 +1544,7 @@ def main(args):
                 args.overlapping_channels,
                 sr_config,
                 ggf_modelname=args.ggf_modelname,
+                tt_glopart_cut=args.tt_glopart_cut,
             )
             plot_dir.mkdir(parents=True, exist_ok=True)
 
@@ -1533,6 +1562,7 @@ def main(args):
                 outfile=args.outfile,
                 dataMinusSimABCD=args.dataMinusSimABCD,
                 showNonDataDrivenPortion=args.showNonDataDrivenPortion,
+                tt_glopart_cut=args.tt_glopart_cut,
             )
 
             # Register for future vetoes (key includes channel to avoid overwrites)
@@ -1669,6 +1699,19 @@ Examples:
         help="Optimize for sum of SM signals (ggF+VBF) instead of single signal",
     )
     sr_group.add_argument(
+        "--gen-split",
+        action="store_true",
+        default=False,
+        help=(
+            "Legacy behavior: restrict each channel's signal sample to events whose gen-truth "
+            "tau decay mode matches the channel (GenTau<channel>). Default (False) instead loads "
+            "the full, gen-truth-unsplit signal sample per channel, so channel membership is "
+            "decided purely by reco-level SR cuts + the existing cross-channel veto chain, same "
+            "as data/background -- signal migrating across channels at reco level is neither "
+            "lost nor invisible. Pass --gen-split to recover the old behavior for comparison."
+        ),
+    )
+    sr_group.add_argument(
         "--do-vbf",
         action="store_true",
         default=False,
@@ -1734,6 +1777,18 @@ Examples:
         default="bbFatJetParTXbbvsQCDTop",
         choices=["bbFatJetParTXbbvsQCD", "bbFatJetParTXbbvsQCDTop", "bbFatJetPNetXbbvsQCDLegacy"],
         help="bb discriminator variable",
+    )
+    disc_group.add_argument(
+        "--tt-glopart-cut",
+        type=float,
+        default=None,
+        help=(
+            "Extra fixed cut on the tt GloParT tagger "
+            "(ttFatJetParTX<channel>vsQCDTop), applied on top of --bb-disc and the tt "
+            "discriminant being optimized (BDT or ParT, per --use-ParT). Useful to test "
+            "combining a BDT cut with an additional GloParT cut. Only respected by the "
+            "'sensitivity' and 'evaluate' actions (default: None, i.e. no extra cut)."
+        ),
     )
     disc_group.add_argument(
         "--compute-ROC-metrics",

--- a/src/bbtautau/postprocessing/bash_scripts/MakeTemplates.sh
+++ b/src/bbtautau/postprocessing/bash_scripts/MakeTemplates.sh
@@ -21,13 +21,13 @@
 
 years=("2022" "2022EE" "2023" "2023BPix")
 channels=("hh" "hm" "he")
-bmin_values=(5 9 10 11 12)  # Can be overridden with --bmin
+bmin_values=(5 9 10 11 12 15)  # Can be overridden with --bmin
 
 # Repo root (parent of src/); works for any user/checkout path
 MAIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
 SCRIPT_DIR="${MAIN_DIR}/src/bbtautau/postprocessing"
 DATA_DIR="/ceph/cms/store/user/lumori/bbtautau/skimmer/26Mar5All_v12_private_signal"
-SENSITIVITY_DIR="${MAIN_DIR}/plots/SensitivityStudy/2026-05-08/"
+SENSITIVITY_DIR="${MAIN_DIR}/plots/SensitivityStudy/2026-06-16/"
 COMBINED_SIGNALS="separate_signals"
 TAG=""
 USE_PART=0
@@ -35,6 +35,7 @@ DO_VBF=0
 USE_SENSITIVITY_DIR=1  # Flag to control --sensitivity-dir argument (default: on)
 TEST_MODE=0
 TT_PRES=0
+CONTROL_REGION=0  # Build CR (annulus) templates for QCD+DY validation
 GGF_MODEL="May4_optimized_ggf"
 #"19oct25_ak4away_ggfbbtt"
 VBF_MODEL="May4_optimized_vbfk2v0"
@@ -52,6 +53,7 @@ show_help() {
     echo "  --channel CHANNEL      Channel to run on (default: all channels)"
     echo "  --use-part             Use ParT tagger instead of BDT"
     echo "  --do-vbf               Include VBF signal regions"
+    echo "  --control-region       Build CR (annulus) templates for QCD+DY validation"
     echo "  --sensitivity-dir DIR  Directory for --sensitivity-dir (default: /home/users/lumori/bbtautau/plots/SensitivityStudy/2025-12-27/)"
     echo "  --no-sensitivity-dir   Disable the --sensitivity-dir argument (default: enabled)"
     echo "  --test-mode            Run in test mode (reduced data size)"
@@ -125,6 +127,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --tt-pres)
             TT_PRES=1
+            shift
+            ;;
+        --control-region)
+            CONTROL_REGION=1
             shift
             ;;
         --ggf-model)
@@ -223,6 +229,11 @@ do
         # Add --tt-pres if enabled
         if [[ $TT_PRES -eq 1 ]]; then
             cmd+=(--tt-pres)
+        fi
+
+        # Add --control-region if enabled (CR annulus templates)
+        if [[ $CONTROL_REGION -eq 1 ]]; then
+            cmd+=(--control-region)
         fi
 
         # Add --combined-signals when set (non-empty string)

--- a/src/bbtautau/postprocessing/bdt_utils.py
+++ b/src/bbtautau/postprocessing/bdt_utils.py
@@ -21,8 +21,11 @@ from bbtautau.postprocessing.bbtautau_types import Channel, LoadedSample
 from bbtautau.postprocessing.bdt_config import BDT_CONFIG
 from bbtautau.postprocessing.Samples import CHANNELS, canonical_signal_key
 
-# Non-interactive backend for batch/containers
-mpl.use("Agg")
+# Non-interactive backend for batch/containers, but don't clobber an already-interactive
+# backend (e.g. a Jupyter notebook's inline backend, "module://...") -- otherwise importing
+# this module from a notebook silently breaks plt.show().
+if not mpl.get_backend().startswith("module://"):
+    mpl.use("Agg")
 
 # Channel order for BDT models (must match the order used in training)
 # This defines the order of channels for each signal: he, hh, hm

--- a/src/bbtautau/postprocessing/control_region_closure.py
+++ b/src/bbtautau/postprocessing/control_region_closure.py
@@ -1,0 +1,246 @@
+"""
+Control-region (CR) closure for the data-driven QCD+DY (alphabet) background estimate.
+
+Tests whether the CR-fail mass shape, scaled by the pass/fail transfer factor, reproduces
+the CR-pass data (after adding the non-QCD/DY MC). Good closure in this high-stats,
+unblindable annulus supports the fail->pass extrapolation used in the signal region.
+
+------------------------------------------------------------------------------------------
+HOW TO RUN
+------------------------------------------------------------------------------------------
+1. Produce the CR templates with the main postprocessor (--control-region writes them under
+   <template-dir>/control/bmin_<b>/<signal>/<channel>/<year>_templates.pkl):
+
+    micromamba run -n hh python -m bbtautau.postprocessing.postprocessing \
+        --control-region --templates --year 2022 --channel hh --bmin 10 \
+        --template-dir src/bbtautau/postprocessing/templates/<tag>   [other template args]
+
+2. Run this closure on those templates:
+
+    micromamba run -n hh python -m bbtautau.postprocessing.control_region_closure \
+        --template-dir src/bbtautau/postprocessing/templates/<tag> \
+        --year 2022 --channel hh --bmin 10 --signal ggfbbtt
+
+Args: --template-dir (parent dir passed in step 1), --year (one or more, summed),
+--channel (he/hh/hm), --bmin, --signal (default ggfbbtt), --out (optional png path;
+defaults under <template-dir>/control/). Prints a chi2/ndf and the per-bin transfer
+factor, and saves a per-sample stacked closure plot (each MC background shown separately
+plus the data-driven QCD+DY) with a data/prediction ratio panel.
+------------------------------------------------------------------------------------------
+
+Closure logic (per mass bin i):
+    qcd_dy_fail_i = data_fail_i - sum(nonQCDDY_MC_fail_i)     # data-driven QCD+DY shape
+    qcd_dy_pass_i = data_pass_i - sum(nonQCDDY_MC_pass_i)
+    qcd_eff       = sum_i qcd_dy_pass_i / sum_i qcd_dy_fail_i # 0th-order TF (flat)
+    pred_pass_i   = qcd_eff * qcd_dy_fail_i + sum(nonQCDDY_MC_pass_i)
+Compare pred_pass to data_pass. The per-bin TF (qcd_dy_pass/qcd_dy_fail) vs mass reveals
+any mass dependence -- exactly the residual the SR Bernstein polynomial absorbs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pickle
+from pathlib import Path
+
+import hist
+import numpy as np
+from boostedhh.hh_vars import LUMI
+from hist import Hist
+
+from bbtautau.postprocessing import plotting
+from bbtautau.postprocessing.Samples import CHANNELS, SAMPLES
+
+DATA_KEY = "data"
+
+# Data-driven QCD+DY is stacked as a single synthetic sample under this key; reuse the
+# colour/label that plotting.py already defines for it.
+QCDDY_KEY = "qcddy"
+
+# Non-QCD/DY MC backgrounds (subtracted from data to expose the data-driven QCD+DY).
+# QCD and DY(->ll, 'dyjets') are intentionally NOT here -- they are the data-driven part.
+NONQCDDY_BG_KEYS = [
+    k for k, s in SAMPLES.items() if s.get_type() == "bg" and k not in ("qcd", "dyjets")
+]
+
+
+def cr_template_path(template_dir: Path, year: str, channel: str, signal: str, bmin: int) -> Path:
+    """Path of the CR templates pickle (mirrors postprocessing.py's control/ layout)."""
+    return (
+        Path(template_dir) / "control" / f"bmin_{bmin}" / signal / channel / f"{year}_templates.pkl"
+    )
+
+
+def load_cr_templates(
+    template_dir: Path, years: list[str], channel: str, signal: str, bmin: int
+) -> dict:
+    """Load CR templates for one or more years, summing the per-region hists across years."""
+    combined: dict = {}
+    for year in years:
+        path = cr_template_path(template_dir, year, channel, signal, bmin)
+        with path.open("rb") as f:
+            tmpl = pickle.load(f)
+        for region in ("pass", "fail"):
+            combined[region] = (
+                tmpl[region] if region not in combined else combined[region] + tmpl[region]
+            )
+    return combined
+
+
+def _vals(h, sample: str) -> np.ndarray:
+    return h[sample, :].values()
+
+
+def qcd_dy_shape(h) -> np.ndarray:
+    """Data-driven QCD+DY per-bin yield = data - non-QCD/DY MC."""
+    mc = np.sum([_vals(h, k) for k in NONQCDDY_BG_KEYS], axis=0)
+    return _vals(h, DATA_KEY) - mc
+
+
+def nonqcddy_mc(h) -> np.ndarray:
+    return np.sum([_vals(h, k) for k in NONQCDDY_BG_KEYS], axis=0)
+
+
+def run_closure(templates: dict) -> dict:
+    """Compute the closure arrays from a CR templates dict (keys 'pass'/'fail')."""
+    hp, hf = templates["pass"], templates["fail"]
+    # axes[0] is the Sample (StrCategory) axis; the mass axis is what remains after
+    # indexing a sample, so read the binning from there.
+    mass_axis = hp[DATA_KEY, :].axes[0]
+    edges = mass_axis.edges
+    centers = mass_axis.centers
+
+    qcd_dy_fail = qcd_dy_shape(hf)
+    qcd_dy_pass = qcd_dy_shape(hp)
+    mc_pass = nonqcddy_mc(hp)
+    data_pass = _vals(hp, DATA_KEY)
+
+    # 0th-order (flat) transfer factor from the integrated pass/fail QCD+DY ratio.
+    qcd_eff = qcd_dy_pass.sum() / qcd_dy_fail.sum()
+    pred_qcd_dy_pass = qcd_eff * qcd_dy_fail
+    pred_pass = pred_qcd_dy_pass + mc_pass
+
+    # per-bin TF reveals mass dependence (the SR Bernstein residual)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        tf_perbin = np.where(qcd_dy_fail > 0, qcd_dy_pass / qcd_dy_fail, np.nan)
+
+    return {
+        "centers": centers,
+        "edges": edges,
+        "data_pass": data_pass,
+        "mc_pass": mc_pass,
+        "qcd_dy_fail": qcd_dy_fail,
+        "qcd_dy_pass": qcd_dy_pass,
+        "pred_qcd_dy_pass": pred_qcd_dy_pass,
+        "pred_pass": pred_pass,
+        "qcd_eff": qcd_eff,
+        "tf_perbin": tf_perbin,
+    }
+
+
+def build_pred_hist(templates: dict, res: dict) -> tuple[Hist, list[str]]:
+    """Pack the CR-pass prediction into a Hist for plotting.ratioHistPlot.
+
+    Each non-QCD/DY MC background is kept as its own sample (so the stack shows them
+    individually), the data-driven QCD+DY (TF x fail) goes into a single ``qcddy`` sample,
+    and the observed CR-pass data goes into ``data``.
+    Returns (hist, ordered background keys to stack).
+    """
+    hp = templates["pass"]
+    present = list(hp.axes["Sample"])
+    mc_keys = [k for k in NONQCDDY_BG_KEYS if k in present]
+    bg_keys = mc_keys + [QCDDY_KEY]
+
+    mass_axis = hp[DATA_KEY, :].axes[0]
+    samples = bg_keys + [DATA_KEY]
+    h = Hist(hist.axis.StrCategory(samples, name="Sample"), mass_axis, storage="double")
+
+    for k in mc_keys:
+        h.view()[samples.index(k), :] = _vals(hp, k)
+    h.view()[samples.index(QCDDY_KEY), :] = res["pred_qcd_dy_pass"]
+    h.view()[samples.index(DATA_KEY), :] = res["data_pass"]
+
+    return h, bg_keys
+
+
+def plot_closure(
+    templates: dict,
+    res: dict,
+    channel: str,
+    year_label: str,
+    out: Path | None = None,
+):
+    """Per-sample CR-pass closure: each MC background stacked separately, the data-driven
+    QCD+DY prediction (TF x fail) on top, compared to data with a data/pred ratio panel."""
+    h, bg_keys = build_pred_hist(templates, res)
+
+    # add_cms_label only knows single years or 'all'; use 'all' when several are summed.
+    cms_year = year_label if year_label in LUMI else "all"
+
+    if out is not None:
+        out.parent.mkdir(parents=True, exist_ok=True)
+
+    plotting.ratioHistPlot(
+        h,
+        cms_year,
+        CHANNELS[channel],
+        sig_keys=[],
+        bg_keys=bg_keys,
+        data_err=True,
+        region_label=f"{CHANNELS[channel].label} CR Pass",
+        name=str(out) if out is not None else "",
+        show=False,
+        ratio_ylims=[0, 2],
+        cmslabel="Work in progress",
+        # blind_region =SHAPE_VAR["blind_window"],
+        leg_args={"fontsize": 16, "ncol": 2},
+    )
+    if out is not None:
+        print(f"Saved closure plot to {out}")
+
+
+def _chi2(res: dict) -> tuple[float, int]:
+    """Simple chi2 of data vs prediction using Poisson data errors (bins with data>0)."""
+    data, pred = res["data_pass"], res["pred_pass"]
+    mask = data > 0
+    chi2 = np.sum((data[mask] - pred[mask]) ** 2 / data[mask])
+    return float(chi2), int(mask.sum())
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--template-dir", required=True, type=Path)
+    parser.add_argument("--year", required=True, nargs="+", help="one or more years (summed)")
+    parser.add_argument("--channel", required=True)
+    parser.add_argument("--signal", default="ggfbbtt")
+    parser.add_argument("--bmin", type=int, default=10)
+    parser.add_argument("--out", type=Path, default=None, help="output plot path (png)")
+    args = parser.parse_args()
+
+    templates = load_cr_templates(
+        args.template_dir, args.year, args.channel, args.signal, args.bmin
+    )
+    year_label = "+".join(args.year)
+
+    res = run_closure(templates)
+    chi2, ndf = _chi2(res)
+
+    print(f"\nCR closure: channel={args.channel} year={year_label} bmin={args.bmin}")
+    print(f"  non-QCD/DY MC subtracted: {NONQCDDY_BG_KEYS}")
+    print(
+        f"  CR-pass data={res['data_pass'].sum():.0f}  pred={res['pred_pass'].sum():.0f}  "
+        f"qcd_eff={res['qcd_eff']:.3e}"
+    )
+    print(f"  chi2/ndf = {chi2:.1f}/{ndf} = {chi2/max(ndf,1):.2f}")
+    print("  per-bin TF (mass dependence -> SR residual):")
+    for m, tf in zip(res["centers"], res["tf_perbin"]):
+        print(f"    m={m:6.1f}  TF={tf:.3e}")
+
+    out = args.out or (
+        args.template_dir / "control" / f"closure_{args.channel}_{year_label}_bmin{args.bmin}.png"
+    )
+    plot_closure(templates, res, channel=args.channel, year_label=year_label, out=out)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/bbtautau/postprocessing/plot_cuts_hist.py
+++ b/src/bbtautau/postprocessing/plot_cuts_hist.py
@@ -573,6 +573,11 @@ def build_hist_for_sample_with_cuts(
         cut_var: Variable name on which cuts are applied
     """
     cut_labels = list(cuts_dict.keys())
+
+    def _neglog_transform(x, eps: float = MIN_LOG):
+        """x -> -log(1 - x + eps); eps only for numerical stability near x = 1."""
+        return -np.log(np.maximum(1.0 - x + eps, 1e-12))
+
     h = Hist(
         hist.axis.StrCategory(cut_labels, name="cut_level"),
         hist.axis.Regular(bins, x_min, x_max, name=varname),
@@ -604,7 +609,7 @@ def build_hist_for_sample_with_cuts(
 
     for label, threshold in cuts_dict.items():
         sel = xcut >= threshold
-        vals_sel = vals[sel]
+        vals_sel = _neglog_transform(vals[sel])
         weight_sel = weight[sel]
 
         print(
@@ -1436,7 +1441,7 @@ def run_cuts_hist_mode(args, channel: Channel, channel_name: str, years: list[st
     if args.cut_var is not None:
         cut_var = args.cut_var
     elif args.use_bdt:
-        cut_var = f"BDTScore{taukey}vsAll"
+        cut_var = f"BDTggfbb{taukey}vsAll"
     else:
         cut_var = f"ttFatJetParTX{taukey}vsQCDTop"
     print(f"Applying cuts on variable: {cut_var}")
@@ -1488,8 +1493,8 @@ def run_cuts_hist_mode(args, channel: Channel, channel_name: str, years: list[st
         model_dir=Path(args.model_dir),
         bdt_eval_dir=Path(args.bdt_eval_dir),
         at_inference=args.at_inference,
-        load_bgs=True,  # Load backgrounds for plotting
-        load_data=True,  # Load data for plotting
+        load_bgs=False,  # Load backgrounds for plotting
+        load_data=False,  # Load data for plotting
     )
 
     # Merge events across all years for plotting
@@ -1555,6 +1560,7 @@ def run_cuts_hist_mode(args, channel: Channel, channel_name: str, years: list[st
                     cmslabel="Work in progress",
                     name=str(save_path),
                     show=False,
+                    log=True,
                 )
                 print(f"Saved {save_path}")
 
@@ -1729,7 +1735,7 @@ def main():
     parser.add_argument(
         "--thresholds",
         nargs="+",
-        default=[0.1, 0.3, 0.5, 0.8, 0.9, 0.95],
+        default=[0.8, 0.9, 0.95, 0.98],
         help="Thresholds to plot (required for --cuts-hist)",
     )
     parser.add_argument(
@@ -1777,7 +1783,7 @@ def main():
         default=2,
         help="Step size for selecting Bmin columns (default: 2, only for --cuts-hist)",
     )
-    parser.add_argument("--modelname", type=str, default="29July25_loweta_lowreg")
+    parser.add_argument("--modelname", type=str, default="May4_optimized_ggf")
     parser.add_argument(
         "--model-dir",
         type=str,

--- a/src/bbtautau/postprocessing/plotting.py
+++ b/src/bbtautau/postprocessing/plotting.py
@@ -19,7 +19,7 @@ from boostedhh.hh_vars import data_key
 from hist import Hist
 
 from bbtautau.postprocessing.bbtautau_types import FOM, Channel
-from bbtautau.postprocessing.Samples import SAMPLES
+from bbtautau.postprocessing.Samples import CHANNELS, SAMPLES
 
 plt.style.use(hep.style.CMS)
 hep.style.use("CMS")
@@ -53,6 +53,58 @@ BG_COLOURS = {
     "zjets": "gray",
     "hbb": "beige",
 }
+
+# Diagnostic truth-decay-mode signal breakdown (see "Signal channel splitting" in CLAUDE.md).
+# `f"{sig_key}__true{origin}"` categories are nominal-only and additive to the (unchanged)
+# total `sig_key` entry -- auto-detected below and drawn as a same-colour stacked breakdown
+# under the existing total-signal step line, distinguished from backgrounds by hatch/alpha.
+TRUTH_ORIGINS = [*CHANNELS, "other"]
+TRUTH_ORIGIN_LABELS = {**{k: CHANNELS[k].label for k in CHANNELS}, "other": "other"}
+TRUTH_ORIGIN_STYLE = {
+    "hh": {"alpha": 0.55, "hatch": "//"},
+    "hm": {"alpha": 0.5, "hatch": "\\\\"},
+    "he": {"alpha": 0.45, "hatch": "xx"},
+    "other": {"alpha": 0.25, "hatch": ".."},
+}
+
+
+def _plot_truth_origin_breakdown(ax, hists: Hist, sig_keys: list[str], sig_scale_dict: dict = None):
+    """Draw, for each ``sig_key`` that has ``{sig_key}__true{origin}`` categories in ``hists``,
+    a stacked breakdown by true tau-decay-mode origin, scaled the same as the (unstacked) total
+    signal line so the stack top lines up with it. No-op if no such categories are present.
+    """
+    sample_names = set(hists.axes[0])
+    sig_scale_dict = sig_scale_dict or {}
+    edges = hists.axes[1].edges
+    drew_any = False
+
+    for i, sig_key in enumerate(sig_keys):
+        sub_keys = [
+            (origin, f"{sig_key}__true{origin}")
+            for origin in TRUTH_ORIGINS
+            if f"{sig_key}__true{origin}" in sample_names
+        ]
+        if not sub_keys:
+            continue
+
+        color = plotting.SIG_COLOURS[i % len(plotting.SIG_COLOURS)]
+        scale = sig_scale_dict.get(sig_key, 1)
+        baseline = np.zeros(len(edges) - 1)
+        for origin, sub_key in sub_keys:
+            vals = hists[sub_key, :].values() * scale
+            style = TRUTH_ORIGIN_STYLE.get(origin, {"alpha": 0.5, "hatch": None})
+            ax.stairs(
+                baseline + vals,
+                edges,
+                baseline=baseline,
+                fill=True,
+                color=color,
+                label=f"{sample_label_map.get(sig_key, sig_key)} ({TRUTH_ORIGIN_LABELS.get(origin, origin)} truth)",
+                **style,
+            )
+            baseline = baseline + vals
+        drew_any = True
+    return drew_any
 
 
 def create_blinded_histogram(hists: Hist, blind_region: list, axis=0):
@@ -145,6 +197,12 @@ def ratioHistPlot(
         axraxsax=axraxsax,
         **kwargs,
     )
+
+    # Diagnostic truth-decay-mode signal breakdown, auto-detected from `hists` (see
+    # TRUTH_ORIGINS above) -- no-op unless `__true*` categories are present. Drawn after the
+    # base plot so it needs its own legend rebuild to be included.
+    if _plot_truth_origin_breakdown(ax, plot_hists, sig_keys, kwargs.get("sig_scale_dict")):
+        ax.legend(*ax.get_legend_handles_labels(), **kwargs.get("leg_args", {"fontsize": 24}))
 
     ax.text(
         0.03,

--- a/src/bbtautau/postprocessing/postprocessing.py
+++ b/src/bbtautau/postprocessing/postprocessing.py
@@ -46,7 +46,7 @@ control_plot_vars = (
     ]
     + [
         ShapeVar(
-            var=f"{jet}FatJetCAglobalParT_massVisApplied_with_delta_axis_merged",
+            var=f"{jet}FatJetCAglobalParT_massVisApplied",
             label=rf"$m^{{{jlabel}}}$ [GeV]",
             bins=[20, 50, 300],
         )
@@ -222,6 +222,7 @@ def main(args: argparse.Namespace):
         models=models,
         cutflow=True,
         load_bgs=True,
+        restrict_signal_to_channel_gen=args.gen_split,
     )
 
     # Keep dictionary structure consistent with legacy code, working out templates one year at a time
@@ -506,6 +507,7 @@ def run_control_plots(args: argparse.Namespace) -> None:
         models=models,
         cutflow=False,
         load_bgs=True,
+        restrict_signal_to_channel_gen=args.gen_split,
     )
 
     if len(years) > 1:
@@ -726,6 +728,15 @@ def get_templates(
         # set up samples
         hist_samples = list(events_dict.keys())
 
+        # Extra, diagnostic-only categories: split each signal sample's (already
+        # reco-selected) events by true tau decay mode, so we can inspect whether
+        # cross-channel-migrated/contaminating signal has a different shape. These are
+        # *not* looked at by CreateDatacard.py (mc_samples/sig_keys there only ever
+        # reference the base `skey` names below), so they can't affect the fit -- purely
+        # additive bookkeeping. See "Signal channel splitting" in CLAUDE.md.
+        for sig_key in sig_keys:
+            hist_samples += [f"{sig_key}__true{origin}" for origin in putils.TRUTH_ORIGINS]
+
         # if not do_jshift:
         #     # add all weight-based variations to histogram axis
         #     for shift in ["down", "up"]:
@@ -764,6 +775,20 @@ def get_templates(
 
             # breakpoint()
             h.fill(Sample=skey, **fill_data, weight=weight)
+
+            if skey in sig_keys:
+                # diagnostic truth-origin breakdown (nominal weight only, no shape
+                # systematics) -- see hist_samples note above
+                for origin, mask in putils.truth_origin_masks(sample).items():
+                    sub_sample = sample.copy_from_selection(mask)
+                    if not len(sub_sample.events):
+                        continue
+                    sub_fill_data = utils.get_fill_data(sub_sample, shape_vars)
+                    h.fill(
+                        Sample=f"{skey}__true{origin}",
+                        **sub_fill_data,
+                        weight=sub_sample.get_var(weight_key),
+                    )
 
             if not do_jshift:
                 # add weight variations
@@ -1078,6 +1103,17 @@ def parse_args(parser=None):
     add_bool_arg(parser, "read-sig-samples", "read signal samples from directory", default=False)
     add_bool_arg(parser, "data", "include data", default=True)
     add_bool_arg(parser, "filters", "apply filters", default=True)
+    add_bool_arg(
+        parser,
+        "gen-split",
+        "legacy behavior: restrict each channel's signal sample to events whose gen-truth tau "
+        "decay mode matches the channel (GenTau<channel>). Default (False) instead loads the "
+        "full, gen-truth-unsplit signal sample per channel, so channel membership is decided "
+        "purely by reco-level SR cuts + the existing cross-channel veto chain, same as "
+        "data/background -- signal migrating across channels at reco level is neither lost nor "
+        "invisible. Pass --gen-split to recover the old behavior for comparison",
+        default=False,
+    )
 
     parser.add_argument(
         "--control-plot-vars",

--- a/src/bbtautau/postprocessing/postprocessing.py
+++ b/src/bbtautau/postprocessing/postprocessing.py
@@ -26,7 +26,7 @@ from hist import Hist
 import bbtautau.postprocessing.utils as putils
 from bbtautau.postprocessing import Regions, Samples, plotting
 from bbtautau.postprocessing.bbtautau_types import Channel, LoadedSample
-from bbtautau.postprocessing.Samples import CHANNELS, SAMPLES, SIGNALS
+from bbtautau.postprocessing.Samples import CHANNELS, SAMPLES, SIGNALS, SM_SIGNALS
 from bbtautau.postprocessing.utils import load_data_channel
 from bbtautau.userConfig import (
     CHANNEL_ORDERING,
@@ -152,6 +152,17 @@ control_plot_vars = (
     + [ShapeVar(var="nBoostedTaus", label=r"Number of Boosted Taus", bins=[3, 0, 3])]
 )
 
+# Control-plot variables whose values pile up near 1 (discriminator scores) are nicer to look
+# at under x -> -log(1 - x + eps). Edit this set to control which vars get transformed.
+TRANSFORM_EPS = 1e-4
+TRANSFORM_VARS = {sv.var for sv in control_plot_vars if "vsQCD" in sv.var}
+
+
+def _neglog_transform(x, eps: float = TRANSFORM_EPS):
+    """x -> -log(1 - x + eps); eps only for numerical stability near x = 1."""
+    return -np.log(np.maximum(1.0 - x + eps, 1e-12))
+
+
 # fitting on bb regressed mass
 shape_vars = [
     ShapeVar(
@@ -248,15 +259,22 @@ def main(args: argparse.Namespace):
 
         for signal_key in signal_regions:
 
-            # Create bmin-specific directories
+            # Create bmin-specific directories ("control" subdir keeps CR templates
+            # from colliding with the nominal SR ones).
+            cr_seg = "control" if args.control_region else ""
             template_dir_bmin = (
                 args.template_dir
+                / cr_seg
                 / f"bmin_{bmin}"
                 / signal_key
                 / (CHANNEL.key if args.template_dir else "")
             )
             plot_dir_bmin = (
-                args.plot_dir / f"bmin_{bmin}" / signal_key / (CHANNEL.key if args.plot_dir else "")
+                args.plot_dir
+                / cr_seg
+                / f"bmin_{bmin}"
+                / signal_key
+                / (CHANNEL.key if args.plot_dir else "")
             )
 
             if template_dir_bmin:
@@ -302,6 +320,7 @@ def main(args: argparse.Namespace):
                     "overlapping_channels": args.overlapping_channels,
                     "sensitivity_disc_tag": args.sensitivity_disc_tag,
                     "ggf_modelname": args.ggf_modelname,
+                    "control_region": args.control_region,
                 },
             )
 
@@ -378,12 +397,30 @@ def control_plots(
 
     for shape_var in control_plot_vars:
         if shape_var.var not in hists:
+            # For flagged vars, fill -log(1 - x + eps) over a matching (transformed) axis so that
+            # ratioHistPlot — which just plots whatever axis the Hist carries — shows the stretched
+            # view. The hist stays keyed by the original var name.
+            if shape_var.var in TRANSFORM_VARS:
+                edges = shape_var.axis.edges
+                tlo, thi = _neglog_transform(np.array([edges[0], edges[-1]]))
+                hist_shape_var = ShapeVar(
+                    var=shape_var.var,
+                    label=shape_var.label + r" [$-\log(1-x+\epsilon)$]",
+                    bins=[shape_var.axis.size, float(tlo), float(thi)],
+                    significance_dir=shape_var.significance_dir,
+                )
+                transform = _neglog_transform
+            else:
+                hist_shape_var = shape_var
+                transform = None
+
             hists[shape_var.var] = putils.singleVarHist(
                 events_dict,
-                shape_var,
+                hist_shape_var,
                 channel,
                 weight_key=weight_key,
                 selection=selection,
+                transform=transform,
             )
 
     ylim = (np.max([h.values() for h in hists.values()]) * 1.05) if same_ylim else None
@@ -417,7 +454,8 @@ def control_plots(
                 cutlabel=cutlabel,
                 show=show,
                 log=log,
-                ylim=pylim if not log else 1e15,
+                plot_data=False,
+                ylim=pylim if not log else 1e1,
                 plot_ratio=plot_ratio,
                 cmslabel="Work in progress",
                 leg_args={"fontsize": 18},
@@ -441,11 +479,11 @@ def run_control_plots(args: argparse.Namespace) -> None:
     elif not isinstance(args.years, list):
         raise ValueError("Cannot process multiple years at once other than 'all'")
     else:
-        years = [args.years]
+        years = args.years
         year_label = args.years
 
     if args.sigs is None:
-        args.sigs = SIGNALS
+        args.sigs = SM_SIGNALS
 
     if args.bgs is None:
         args.bgs = {bkey: b for bkey, b in SAMPLES.items() if b.get_type() == "bg"}
@@ -456,8 +494,8 @@ def run_control_plots(args: argparse.Namespace) -> None:
     CHANNEL = CHANNELS[args.channel]
 
     models = None
-    # if not args.use_ParT:
-    #     models = [args.ggf_modelname] + ([args.vbf_modelname] if args.do_vbf else [])
+    if not args.use_ParT:
+        models = [args.ggf_modelname] + ([args.vbf_modelname] if args.do_vbf else [])
 
     events_dict = load_data_channel(
         years=years,
@@ -495,7 +533,46 @@ def run_control_plots(args: argparse.Namespace) -> None:
     else:
         selected_vars = list(control_plot_vars)
 
-    # For now: inclusive control plots, no additional pass/fail selections.
+    # Default: inclusive control plots. With --sr, apply the SR pass cut (resolved from --bmin).
+    selection = None
+    cutstr = ""
+    cutlabel = "Inclusive"
+    title = f"{CHANNEL.label} inclusive control plots"
+
+    if args.sr:
+        # Resolve the SR pass region for the ggf signal and turn its cuts into a per-sample mask.
+        bmin = args.bmin[0] if isinstance(args.bmin, list) else args.bmin
+        if isinstance(args.bmin, list) and len(args.bmin) > 1:
+            print(f"--sr: multiple --bmin values given {args.bmin}; using the first ({bmin}).")
+        if args.sensitivity_dir is None:
+            print(
+                "--sr: --sensitivity-dir not set; SR cuts fall back to Samples.py defaults and "
+                "--bmin has no effect."
+            )
+
+        signal = "ggfbbtt"
+        selection_regions = Regions.get_selection_regions(
+            signal,
+            CHANNEL,
+            sensitivity_dir=args.sensitivity_dir,
+            bmin=bmin,
+            combined_signals=args.combined_signals,
+            use_ParT=args.use_ParT,
+            do_vbf=args.do_vbf,
+            bb_disc=args.bb_disc,
+            test_mode=args.test_mode,
+            tt_pres=args.tt_pres,
+            overlapping_channels=args.overlapping_channels,
+            sensitivity_disc_tag=args.sensitivity_disc_tag,
+            ggf_modelname=args.ggf_modelname,
+        )
+        pass_region = selection_regions["pass"]
+        selection, _ = utils.make_selection(pass_region.cuts, events_dict)
+
+        cutstr = f"sr_bmin{bmin}_"
+        cutlabel = f"SR pass (Bmin={bmin})"
+        title = f"{CHANNEL.label} SR pass control plots (Bmin={bmin})"
+
     plot_dir_cp = args.plot_dir
     plot_dir_cp.mkdir(parents=True, exist_ok=True)
 
@@ -507,10 +584,10 @@ def run_control_plots(args: argparse.Namespace) -> None:
         control_plot_vars=selected_vars,
         plot_dir=plot_dir_cp,
         year=year_label,  # very inefficient rn
-        selection=None,
-        cutstr="",
-        cutlabel="Inclusive",
-        title=f"{CHANNEL.label} inclusive control plots",
+        selection=selection,
+        cutstr=cutstr,
+        cutlabel=cutlabel,
+        title=title,
         combine_pdf=True,
         plot_ratio=True,
         show=False,
@@ -577,21 +654,26 @@ def get_templates(
     # do TXbb SFs + uncs. for signals and Hbb samples only
     # txbb_samples = sig_keys + [key for key in bg_keys if key in hbb_bg_keys]
 
+    # Inter-channel/-signal vetoes enforce SR orthogonality; the CR is a per-channel
+    # validation region, so skip them when building control-region templates.
+    control_region = bool((selection_region_kwargs or {}).get("control_region", False))
+
     vetoes = []
     found = False
     # veto all channels/signals earlier in the ordering than the current one
-    for channel_iter in CHANNEL_ORDERING:
-        for signal_iter in signal_regions:
-            if channel_iter == channel.key and signal_iter == signal:
-                found = True
-                break
-            vetoes.append(
-                Regions.get_selection_regions(
-                    signal_iter, CHANNELS[channel_iter], **selection_region_kwargs
+    if not control_region:
+        for channel_iter in CHANNEL_ORDERING:
+            for signal_iter in signal_regions:
+                if channel_iter == channel.key and signal_iter == signal:
+                    found = True
+                    break
+                vetoes.append(
+                    Regions.get_selection_regions(
+                        signal_iter, CHANNELS[channel_iter], **selection_region_kwargs
+                    )
                 )
-            )
-        if found:
-            break
+            if found:
+                break
 
     # Now a pass/fail region is defined for ggf and vbf. In each we will load all signal samples
     # Apply vetoes from regions that were optimized earlier in the ordering
@@ -958,6 +1040,13 @@ def parse_args(parser=None):
     )
 
     add_bool_arg(parser, "control-plots", "make control plots", default=False)
+    add_bool_arg(
+        parser,
+        "sr",
+        "for --control-plots, apply the signal-region pass cut (resolved from --bmin / "
+        "--sensitivity-dir) before plotting",
+        default=False,
+    )
 
     add_bool_arg(parser, "blinded", "blind the data in the Higgs mass window", default=True)
     add_bool_arg(parser, "templates", "save m_bb templates", default=False)
@@ -1003,7 +1092,7 @@ def parse_args(parser=None):
     parser.add_argument(
         "--ggf-modelname",
         help="Name of the BDT model to use",
-        default="19oct25_ak4away_ggfbbtt",
+        default="May4_optimized_ggf",
         type=str,
     )
     parser.add_argument(
@@ -1013,9 +1102,17 @@ def parse_args(parser=None):
         help="Run VBF optimization first (with its own model) and veto its selection (Bmin=10) when optimizing the main signal",
     )
     parser.add_argument(
+        "--control-region",
+        action="store_true",
+        default=False,
+        help="Build CR (orthogonal annulus) templates for QCD+DY validation instead of the "
+        "nominal SR pass/fail. Loose cuts from userConfig.CR_LOOSE_CUTS; see "
+        "notes/control_region_plan.md. Templates go to a 'control' subdir; CR is unblinded.",
+    )
+    parser.add_argument(
         "--vbf-modelname",
         help="Name of the BDT model to use",
-        default="19oct25_ak4away_vbfbbtt",
+        default="May4_optimized_vbf",
         type=str,
     )
 
@@ -1095,7 +1192,7 @@ def parse_args(parser=None):
     elif args.data_dir:
         args.signal_data_dirs = [args.data_dir]
 
-    # save args in args.plot_dir and args.template_dir if they exit
+    # save args in args.plot_dir and args.template_dir if they exist
     if args.plot_dir:
         year_label = "+".join(args.years)
         base_plot_dir = Path(args.plot_dir)

--- a/src/bbtautau/postprocessing/utils.py
+++ b/src/bbtautau/postprocessing/utils.py
@@ -223,6 +223,7 @@ def get_columns(
     lowercase_jetaway: bool = False,
     vbf: bool = True,
     all_hlts: bool = False,
+    gen_leptons=False,
 ):
     """
     Build per-sample-type column lists for :func:`load_samples`.
@@ -365,6 +366,17 @@ def get_columns(
         ("GenHiggsChildren", 2),
     ]
 
+    if gen_leptons:
+        columns_signal += [
+            ("GenTauLepEta", 2),
+            ("GenTauLepPhi", 2),
+            ("GenTauLepMass", 2),
+            ("GenTauLepPt", 2),
+            ("GenTauLepId", 2),
+            ("GenTauDecay", 2),
+            ("GenTauNProng", 2),
+        ]
+
     columns = {
         "data": utils.format_columns(columns_data),
         "signal": utils.format_columns(columns_signal),
@@ -389,6 +401,7 @@ def load_samples(
     loaded_samples: bool = True,
     multithread: bool = True,
     loader_n_jobs: int | None = None,
+    restrict_signal_to_channel_gen: bool = True,
 ) -> dict[str, LoadedSample | pd.DataFrame]:
     """
     Loads and preprocesses physics event samples for a given year and analysis channel.
@@ -423,6 +436,16 @@ def load_samples(
         If True, loads only the "ggf" signal samples, excluding "vbf" (default: False). Used for specialized studies.
     loaded_samples : bool, optional
         If True, returns results as `LoadedSample` objects. If False, returns plain DataFrames (deprecated).
+    restrict_signal_to_channel_gen : bool, optional
+        If True (default), each `f"{signal}{channel.key}"` sample is restricted to events whose
+        gen-truth tau decay mode matches that channel (`GenTau{channel.key}`) -- the historical
+        behavior, appropriate for tagger training/characterization against ground truth (e.g.
+        `bdt.py`, ROC studies). If False, each `f"{signal}{channel.key}"` sample instead gets the
+        *full*, unsplit signal sample (all decay modes), so that channel membership is determined
+        purely by reco-level selection + cross-channel vetoes downstream -- same treatment as
+        data/background. Used by the final-template and sensitivity-optimization paths
+        (`postprocessing.py`, `SensitivityStudy.py`) to avoid losing/hiding signal that migrates
+        across channels at reco level. See untracked_utils channel migration diagnostic notebook.
 
     Returns
     -------
@@ -567,16 +590,25 @@ def load_samples(
         for channel in channels:
             if not loaded_samples:
                 # quick fix due to old naming still in samples
-                events_dict[f"{signal}{channel.key}"] = events_dict[signal][
-                    events_dict[signal][f"GenTau{channel.key}"][0]
-                ]
+                if restrict_signal_to_channel_gen:
+                    events_dict[f"{signal}{channel.key}"] = events_dict[signal][
+                        events_dict[signal][f"GenTau{channel.key}"][0]
+                    ]
+                else:
+                    events_dict[f"{signal}{channel.key}"] = events_dict[signal].copy()
                 del events_dict[signal]
             else:
+                if restrict_signal_to_channel_gen:
+                    channel_events = events_dict[signal].events[
+                        events_dict[signal].get_var(f"GenTau{channel.key}")
+                    ]
+                else:
+                    # Full, unsplit signal sample: channel membership is decided purely by
+                    # reco-level selection + cross-channel vetoes downstream, same as data/bg.
+                    channel_events = events_dict[signal].events.copy()
                 events_dict[f"{signal}{channel.key}"] = LoadedSample(
                     sample=Samples.SAMPLES[f"{signal}{channel.key}"],
-                    events=events_dict[signal].events[
-                        events_dict[signal].get_var(f"GenTau{channel.key}")
-                    ],
+                    events=channel_events,
                 )
         del events_dict[signal]
 
@@ -719,6 +751,28 @@ def delete_columns(
                 )
             )
     return events_dict
+
+
+TRUTH_ORIGINS = [*CHANNELS, "other"]
+
+
+def truth_origin_masks(sample: LoadedSample) -> dict[str, np.ndarray]:
+    """Boolean masks splitting a signal ``LoadedSample`` by true tau decay mode, keyed by
+    ``TRUTH_ORIGINS`` (``"hh"``/``"hm"``/``"he"`` from ``GenTau<channel>``, plus ``"other"``
+    for events matching none of them, e.g. ee/emu/mumu decay topologies).
+
+    Diagnostic only: used to *label* already reco-selected signal events for shape-effect
+    inspection (see the channel-migration notes in CLAUDE.md), not to restrict which events
+    are candidates for a channel's SR.
+    """
+    masks = {}
+    any_match = np.zeros(len(sample.events), dtype=bool)
+    for ch_key in CHANNELS:
+        mask = sample.get_var(f"GenTau{ch_key}").astype(bool)
+        masks[ch_key] = mask
+        any_match |= mask
+    masks["other"] = ~any_match
+    return masks
 
 
 def bbtautau_assignment(

--- a/src/bbtautau/postprocessing/utils.py
+++ b/src/bbtautau/postprocessing/utils.py
@@ -1162,8 +1162,6 @@ def load_data_channel(
         derive_vbf_variables(events_dict[year])
 
     # Load or compute BDT predictions for every requested model.
-    # Each model writes signal-specific columns (e.g. BDTggfbb{ch}vsAll, BDTvbfbb{ch}vsAll)
-    # so there is no overwrite risk between models. The caller controls which models to evaluate.
     if models is not None:
         for model in models:
             if model not in BDT_CONFIG:
@@ -1202,6 +1200,7 @@ def singleVarHist(
     bbtt_masks: dict[str, pd.DataFrame] = None,
     weight_key: str = "finalWeight",
     selection: dict | None = None,
+    transform: callable | None = None,
 ) -> Hist:
     """
     Makes and fills a histogram for variable `var` using data in the `events` dict.
@@ -1215,6 +1214,8 @@ def singleVarHist(
           Bins in this region will be set to 0 for data.
         selection (dict, optional): if performing a selection first, dict of boolean arrays for
           each sample
+        transform (callable, optional): if given, applied to the raw variable values before
+          filling. The ``shape_var`` axis must already be defined over the transformed range.
     """
 
     if not isinstance(next(iter(events_dict.values())), LoadedSample):
@@ -1244,6 +1245,9 @@ def singleVarHist(
 
         fill_data = {var: sample.get_var(fill_var)}
         weight = sample.get_var(weight_key)
+
+        if transform is not None and fill_data[var] is not None:
+            fill_data[var] = transform(fill_data[var])
 
         if selection is not None:
             sel = selection[skey]

--- a/src/bbtautau/userConfig.py
+++ b/src/bbtautau/userConfig.py
@@ -98,6 +98,13 @@ CHANNEL_ORDERING = ["hh", "hm", "he"]  # order of applying selection and vetoes
 SIGNAL_ORDERING = ["ggfbbtt", "vbfbbtt"]  # order of applying selection and vetoes
 
 
+CR_LOOSE_CUTS: dict[str, dict[str, float]] = {
+    "hh": {"txbb": 0.5, "txtt": 0.5},  # SR: txbb=0.91, txtt_BDT=0.996
+    "hm": {"txbb": 0.5, "txtt": 0.5},  # SR: txbb=0.85, txtt_BDT=0.8
+    "he": {"txbb": 0.5, "txtt": 0.5},  # SR: txbb=0.91, txtt_BDT=0.9918
+}
+
+
 # Working point bin edges for tt GloParT discriminants
 # Determine using the plot_cuts_hist.py script
 


### PR DESCRIPTION
Overrides #94 . Takes #94 and adds fixes on the signal splitting logic across channels. Now in templates and optimization signal is not gen-split (it is in BDT training or other studies). Kept a split version of histograms to be able to plot split templates and compare shapes. Other minor fixes, including new logic in SensitivityStudy.py to add a fixed GloParT tautau cut on top of BDT and GloParT bb cut.  